### PR TITLE
Upgrade to Laravel 13.7 (Wave 2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,7 @@
 Active Directory & LDAP support for DreamFactory Platform 2.0
 
 This code is governed by a commercial license. To use it, you must follow the [terms of use](http://dreamfactory.com/termsofuse), refer to the LICENSE file.
+
+## Overview
+
+DreamFactory is a secure, self-hosted enterprise data access platform that provides governed API access to any data source, connecting enterprise applications and on-prem LLMs with role-based access and identity passthrough.

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,17 @@
   "minimum-stability": "dev",
   "prefer-stable": true,
   "require":     {
-    "dreamfactory/df-core": "~1.0"
+    "php": "^8.3",
+    "ext-ldap": "*",
+    "laravel/helpers": "^1.8",
+    "dreamfactory/df-core": "~1.0.4"
+  },
+  "require-dev": {
+    "laravel/framework": "^13.7",
+    "mockery/mockery": "^1.6",
+    "nunomaduro/collision": "^8.6",
+    "phpunit/phpunit": "^11.5.3",
+    "orchestra/testbench": "^11.0"
   },
   "autoload":    {
     "psr-4": {


### PR DESCRIPTION
## Summary

Wave 2 of the Laravel 11 -> 13 upgrade campaign. df-adldap is **composer-only**; no source changes required.

### Key finding: no upstream library migration needed

The Wave 2 brief flagged that the original `adldap2/adldap2` and `adldap2/adldap2-laravel` packages are abandoned and may have required migration to `directorytree/ldaprecord-laravel`. **df-adldap does not depend on either** — it uses PHP's native `ldap_*` extension functions directly (`ldap_connect`, `ldap_bind`, `ldap_search`, etc.). Verified via:

```
grep -rn "Adldap\\\\|LdapRecord\\\\|adldap2|ldaprecord" --include="*.php" --include="*.json"
# no matches
```

This means the abandoned-upstream risk is moot for this package and the upgrade collapses to a pure dep matrix bump.

### composer.json changes

```diff
   "require":     {
-    "dreamfactory/df-core": "~1.0"
+    "php": "^8.3",
+    "ext-ldap": "*",
+    "laravel/helpers": "^1.8",
+    "dreamfactory/df-core": "~1.0.4"
+  },
+  "require-dev": {
+    "laravel/framework": "^13.7",
+    "mockery/mockery": "^1.6",
+    "nunomaduro/collision": "^8.6",
+    "phpunit/phpunit": "^11.5.3",
+    "orchestra/testbench": "^11.0"
   },
```

- `php: ^8.3` matches L13's minimum.
- `ext-ldap: *` was implicit; now explicit so `composer install` fails fast on hosts without ldap support.
- `laravel/helpers: ^1.8` polyfills `array_get`, `camel_case`, `array_except` (still used in src/Services/LDAP.php and elsewhere) — moved to production require so consumers don't have to add it.
- `dreamfactory/df-core: ~1.0.4` floors the L13 baseline.

### Survey results (clean across the board)

- No `Fruitcake\Cors\CorsService` references
- No `DispatchesJobs` trait usage (removed in L11)
- No `setupBeforeClass` typos (PHPUnit 11 enforces case-sensitivity)
- No `getDates()` overrides on HasAttributes users
- No `ConnectionInterface::select()/cursor()` stubs needing the L13 4th `array $fetchUsing = []` parameter
- No `Adldap\\` / `LdapRecord\\` namespace references (see above)
- No upstream library dependency at all - pure ext-ldap

## Validation

### Stage 1 (isolated)
- `composer validate --strict --no-check-publish`: passes
- `composer install --no-dev` with path-repo aliases for df-core (1.0.99) + df-system (0.6.99) on `shift/laravel-13`: resolves cleanly, installs Laravel 13.7.0
- `php -l` clean across all 24 src files
- class_exists smoke: **24/24 classes load**, all 3 helper polyfills present, ext-ldap loaded

### Stage 2 (host-app integration)
- Cloned `dreamfactory/dreamfactory@shift-173254`
- Standard Wave-2 strip-list: removed `df-mongo-logs`, `df-git`, `df-oauth`, `df-mcp-server` from require + repositories; commented `MongoDB\Laravel\MongoDBServiceProvider::class` in config/app.php
- Note: df-adldap is **not** in the host composer.json (it's a commercial add-on). Added it under our path-repo alias for validation.
- Path-repo aliases for df-core, df-system, df-adldap (all on shift/laravel-13)
- `composer install --no-dev`: resolves cleanly
- `php artisan package:discover`: discovers `dreamfactory/df-adldap` and registers `DreamFactory\Core\ADLdap\ServiceProvider`
- class_exists smoke: 24/24 classes load under L13.7.0

## Test plan

- [ ] CI green on shift/laravel-13
- [ ] Downstream confirmation: when df-adldap is installed alongside the L13 host app, the `adldap` and `ldap` service types register and the AD/LDAP migrations run cleanly
- [ ] Manual smoke against a real Active Directory / OpenLDAP server (auth bind, group import, role mapping) - no regressions expected since no source changed, but worth a sanity check before tagging