### PR TITLE
release: develop → master cut for Laravel 13 / PHP 8.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,17 @@
   "minimum-stability": "dev",
   "prefer-stable": true,
   "require":     {
-    "dreamfactory/df-core": "~1.0"
+    "php": "^8.3",
+    "ext-ldap": "*",
+    "laravel/helpers": "^1.8",
+    "dreamfactory/df-core": "~1.0.4"
+  },
+  "require-dev": {
+    "laravel/framework": "^13.7",
+    "mockery/mockery": "^1.6",
+    "nunomaduro/collision": "^8.6",
+    "phpunit/phpunit": "^11.5.3",
+    "orchestra/testbench": "^11.0"
   },
   "autoload":    {
     "psr-4": {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.0/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         colors="true">
+    <testsuites>
+        <testsuite name="Security">
+            <directory>tests/Security</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/src/Components/OpenLdap.php
+++ b/src/Components/OpenLdap.php
@@ -127,7 +127,14 @@ class OpenLdap implements Provider
             $user = $this->getUserByUserName($username);
         }
 
-        $search = $this->search("(&(memberUid=$user->uid)(objectClass=posixGroup)$filter)", $attributes);
+        // ldap_escape with LDAP_ESCAPE_FILTER prevents LDAP injection via the
+        // user's uid attribute. The third arg ('') is the chars-to-keep allow
+        // list — empty means escape every metacharacter the spec defines.
+        // $filter is not from caller input (it is a server-trusted addendum
+        // built by getGroups callers) but we still escape its embedded values
+        // when the caller passes user input through it.
+        $escapedUid = ldap_escape((string) $user->uid, '', LDAP_ESCAPE_FILTER);
+        $search = $this->search("(&(memberUid={$escapedUid})(objectClass=posixGroup){$filter})", $attributes);
         $groups = !empty($user->memberof) ? $user->memberof : $search;
         if ((empty($groups) || (isset($groups['count'])) && $groups['count'] === 0) && !is_null($user->groupmembership)) {
             $groups = $user->groupmembership;
@@ -229,7 +236,13 @@ class OpenLdap implements Provider
         $baseDn = (empty($baseDn)) ? $this->baseDn : $baseDn;
         $connection = $this->connection;
 
-        $search = ldap_search($connection, $baseDn, '(' . $uidField . '=' . $username . ')');
+        // Both $uidField (admin-config attribute name like 'uid' or 'sAMAccountName')
+        // and $username (caller-supplied login) are escaped against LDAP filter
+        // metacharacters. Without this, a payload like `*)(uid=*` for $username
+        // breaks out of the filter and matches every entry — auth bypass.
+        $safeUidField = ldap_escape((string) $uidField, '', LDAP_ESCAPE_FILTER);
+        $safeUsername = ldap_escape((string) $username, '', LDAP_ESCAPE_FILTER);
+        $search = ldap_search($connection, $baseDn, '(' . $safeUidField . '=' . $safeUsername . ')');
         $result = ldap_get_entries($connection, $search);
 
         if (isset($result[0]['dn'])) {

--- a/src/Components/OpenLdap.php
+++ b/src/Components/OpenLdap.php
@@ -274,11 +274,8 @@ class OpenLdap implements Provider
     {
 
         $result = [];
-        if (!empty($filter) && substr((string) $filter, 0, 1) != '(') {
-            $filter = '(' . $filter . ')';
-        }
-
-        $groups = $this->getGroups(null, $attributes, $filter);
+        $safeFilter = $this->sanitizeFilterFragment($filter);
+        $groups = $this->getGroups(null, $attributes, $safeFilter);
 
         if (isset($groups['count']) && $groups['count'] === 0) {
             return [];
@@ -292,6 +289,32 @@ class OpenLdap implements Provider
         }
 
         return $result;
+    }
+
+    /**
+     * Accept only a simple LDAP equality fragment for additional group
+     * filtering, and escape the value before it is appended to the full
+     * search filter. Raw LDAP filter fragments are too dangerous here.
+     */
+    protected function sanitizeFilterFragment($filter)
+    {
+        if (empty($filter)) {
+            return '';
+        }
+
+        $filter = trim((string) $filter);
+        if (strlen($filter) > 255) {
+            throw new BadRequestException('LDAP filter is too long.');
+        }
+
+        if (!preg_match('/^\(?\s*([A-Za-z][A-Za-z0-9._:-]*)\s*=\s*([^()]+?)\s*\)?$/', $filter, $matches)) {
+            throw new BadRequestException('Invalid LDAP filter. Only simple attribute=value filters are allowed.');
+        }
+
+        $attribute = $matches[1];
+        $value = ldap_escape(trim($matches[2]), '', LDAP_ESCAPE_FILTER);
+
+        return '(' . $attribute . '=' . $value . ')';
     }
 
     /** @inheritdoc */

--- a/tests/Security/LdapInjectionTest.php
+++ b/tests/Security/LdapInjectionTest.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace DreamFactory\Core\ADLdap\Tests\Security;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Security: LDAP filter strings must escape user-supplied values via
+ * ldap_escape(LDAP_ESCAPE_FILTER).
+ *
+ * Phase 2 audit found two injection sites in OpenLdap.php:
+ *
+ *   - getUserDn():  "($uidField=$username)"
+ *     A login payload like `*)(uid=*` for $username breaks out of the
+ *     intended filter and matches every entry — auth bypass.
+ *
+ *   - getGroups():  "(&(memberUid=$user->uid)(objectClass=posixGroup)$filter)"
+ *     The user's uid attribute (returned from a prior LDAP search but still
+ *     untrusted relative to the filter syntax) was concatenated raw.
+ *
+ * After the fix, both sites route values through ldap_escape with the
+ * LDAP_ESCAPE_FILTER flag.
+ */
+class LdapInjectionTest extends TestCase
+{
+    private string $sourcePath;
+    private string $contents;
+
+    protected function setUp(): void
+    {
+        $this->sourcePath = __DIR__ . '/../../src/Components/OpenLdap.php';
+        $this->assertFileExists($this->sourcePath);
+        $this->contents = file_get_contents($this->sourcePath);
+    }
+
+    public function testGetUserDnEscapesFilterValues(): void
+    {
+        $start = strpos($this->contents, 'function getUserDn');
+        $this->assertNotFalse($start, 'getUserDn() must exist');
+        $next = strpos($this->contents, "\n    /**", $start + 10);
+        $body = substr($this->contents, $start, $next === false ? null : ($next - $start));
+
+        // Forbid the raw concatenation pattern.
+        $this->assertDoesNotMatchRegularExpression(
+            "/'\(' \. \\\$uidField \. '=' \. \\\$username \. '\)'/",
+            $body,
+            'getUserDn() must not concatenate raw $uidField + $username into the LDAP filter'
+        );
+        // Require ldap_escape on both values.
+        $this->assertMatchesRegularExpression(
+            '/ldap_escape\s*\(\s*(?:\([a-z]+\)\s*)?\$username/',
+            $body,
+            'getUserDn() must call ldap_escape on $username'
+        );
+        $this->assertMatchesRegularExpression(
+            '/ldap_escape\s*\(\s*(?:\([a-z]+\)\s*)?\$uidField/',
+            $body,
+            'getUserDn() must call ldap_escape on $uidField'
+        );
+        $this->assertMatchesRegularExpression(
+            '/LDAP_ESCAPE_FILTER/',
+            $body,
+            'getUserDn() must use LDAP_ESCAPE_FILTER mode'
+        );
+    }
+
+    public function testGetGroupsEscapesUid(): void
+    {
+        $start = strpos($this->contents, 'function getGroups');
+        $this->assertNotFalse($start, 'getGroups() must exist');
+        $next = strpos($this->contents, "\n    /**", $start + 10);
+        $body = substr($this->contents, $start, $next === false ? null : ($next - $start));
+
+        $this->assertDoesNotMatchRegularExpression(
+            '/memberUid=\$user->uid/',
+            $body,
+            'getGroups() must not interpolate $user->uid raw into the LDAP filter'
+        );
+        $this->assertMatchesRegularExpression(
+            '/ldap_escape\s*\(\s*(?:\([a-z]+\)\s*)?\$user->uid/',
+            $body,
+            'getGroups() must call ldap_escape on $user->uid'
+        );
+    }
+
+    /**
+     * Behavioral: ldap_escape with LDAP_ESCAPE_FILTER must turn the bypass
+     * payload into a benign substring.
+     */
+    public function testLdapEscapeFlattensBypassPayload(): void
+    {
+        $payload = '*)(uid=*';
+        $escaped = ldap_escape($payload, '', LDAP_ESCAPE_FILTER);
+
+        // Each metachar (* ( ) \ NUL) must be \-hex encoded.
+        $this->assertStringNotContainsString('*', $escaped, 'asterisk must be escaped');
+        $this->assertStringNotContainsString('(', $escaped, 'paren must be escaped');
+        $this->assertStringNotContainsString(')', $escaped, 'paren must be escaped');
+    }
+}

--- a/tests/Security/LdapInjectionTest.php
+++ b/tests/Security/LdapInjectionTest.php
@@ -19,7 +19,9 @@ use PHPUnit\Framework\TestCase;
  *     untrusted relative to the filter syntax) was concatenated raw.
  *
  * After the fix, both sites route values through ldap_escape with the
- * LDAP_ESCAPE_FILTER flag.
+ * LDAP_ESCAPE_FILTER flag. Follow-up hardening also forbids raw caller
+ * filter fragments in listGroup(); it now accepts only a simple
+ * attribute=value fragment and escapes the value before appending it.
  */
 class LdapInjectionTest extends TestCase
 {
@@ -92,9 +94,28 @@ class LdapInjectionTest extends TestCase
         $payload = '*)(uid=*';
         $escaped = ldap_escape($payload, '', LDAP_ESCAPE_FILTER);
 
-        // Each metachar (* ( ) \ NUL) must be \-hex encoded.
+        // Each metachar (* ( ) \\ NUL) must be \\-hex encoded.
         $this->assertStringNotContainsString('*', $escaped, 'asterisk must be escaped');
         $this->assertStringNotContainsString('(', $escaped, 'paren must be escaped');
         $this->assertStringNotContainsString(')', $escaped, 'paren must be escaped');
+    }
+
+    public function testListGroupSanitizesAdditionalFilterFragment(): void
+    {
+        $start = strpos($this->contents, 'function listGroup');
+        $this->assertNotFalse($start, 'listGroup() must exist');
+        $next = strpos($this->contents, "\n    /**", $start + 10);
+        $body = substr($this->contents, $start, $next === false ? null : ($next - $start));
+
+        $this->assertStringContainsString(
+            'sanitizeFilterFragment($filter)',
+            $body,
+            'listGroup() must sanitize caller-provided filter fragments before appending them to the LDAP query'
+        );
+        $this->assertStringNotContainsString(
+            '$this->getGroups(null, $attributes, $filter)',
+            $body,
+            'listGroup() must not pass the raw caller filter straight into getGroups()'
+        );
     }
 }


### PR DESCRIPTION
## Release prep: cut develop into master/main

Releases this package's `develop` line for the upcoming **DreamFactory
Laravel 13 + PHP 8.5** release.

### Verification

The develop HEAD on this branch is the SHA locked into the L13/PHP 8.5
test bundle that the team has been smoking. **Full end-to-end smoke
passed 2026-05-26**: PHP 8.5.5, Laravel 13.11.2, `df:setup` seeders,
admin login → JWT, service-type registration (81 types), Postgres
schema introspection + CRUD, OpenAPI generation.

### Coordinated release PRs

This is one of ~26 coordinated `develop → master/main` PRs opened
together as the release cut. Suggested merge order:

1. **Foundation**: df-core → df-system → df-user → df-database
2. **Connectors**: df-sqldb, df-sqlsrv, df-mongodb, df-oracledb, df-snowflake, df-soap, df-salesforce, df-script
3. **Auth**: df-oauth → df-adldap, df-azure-ad, df-oidc, df-saml
4. **Services**: df-email, df-file, df-cache, df-limits, df-logger, df-scheduler
5. **AI tier**: df-ai → df-ai-chat → df-mcp-server
6. **Admin UI**: df-admin-interface
7. **Host app**: dreamfactory/dreamfactory (released last)

### Customer upgrade path

In-place on Docker / managed Linux packages; blue-green strongly
recommended on Windows + custom-PHP-extension installs. Pre-flight
checklist in the release notes.
