### PR TITLE
Fix AD group import TypeError on PHP 8.1+

### DIFF
--- a/src/Commands/ADGroupImport.php
+++ b/src/Commands/ADGroupImport.php
@@ -83,7 +83,7 @@ class ADGroupImport extends Command
                         'name'                   => static::dnToRoleName($group['dn']),
                         'description'            => $group['description'],
                         'is_active'              => true,
-                        'role_adldap_by_role_id' => ['dn' => $group['dn']]
+                        'role_adldap_by_role_id' => [['dn' => $group['dn']]]
                     ];
 
                     $this->info('|--------------------------------------------------------------------');


### PR DESCRIPTION
## Summary
- Wraps the `role_adldap_by_role_id` relation value in an additional array so `BaseModel::setAttribute()` iterates an array of records instead of string values
- Fixes fatal `TypeError: Model::__construct(): Argument #1 ($attributes) must be of type array, string given` when running `php artisan df:ad-group-import` on PHP 8.1+
- Regression from commit ab15144 (2017) that flattened the array; only surfaced now because PHP 8.1+ enforces strict type hints that PHP 7.x treated as soft warnings

## Test plan
- [ ] Run `php artisan df:ad-group-import <service>` against an AD server with groups
- [ ] Verify roles are created with correct `role_adldap` relation (DN stored)
- [ ] Confirm no TypeError on PHP 8.1/8.2/8.3/8.4